### PR TITLE
Update organization references to opencadc-metadata-curation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /usr/src/app
 ARG CAOM2_BRANCH=master
 ARG CAOM2_REPO=opencadc
 ARG OPENCADC_BRANCH=master
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
 ARG PIPE_REPO=opencadc
 ARG VOS_BRANCH=master

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM opencadc/astropy-5:3.9-slim
+FROM opencadc-metadata-curation/astropy-5:3.9-slim
 
 RUN apt-get update --no-install-recommends && \
     apt-get install -y \
@@ -25,12 +25,12 @@ ARG CAOM2_REPO=opencadc
 ARG OPENCADC_BRANCH=master
 ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 ARG VOS_BRANCH=master
-ARG VOS_REPO=opencadc
+ARG VOS_REPO=opencadc-metadata-curation
 
 # until Storage Inventory support is released to pypi
-RUN git clone https://github.com/opencadc/cadctools.git && \
+RUN git clone https://github.com/opencadc-metadata-curation/cadctools.git && \
     cd cadctools && \
     pip install ./cadcutils && \
     pip install ./cadcdata && \

--- a/scripts/subaru_run.sh
+++ b/scripts/subaru_run.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="subaru"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/subaru_run_remote.sh
+++ b/scripts/subaru_run_remote.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="subaru"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/scripts/subaru_run_state.sh
+++ b/scripts/subaru_run_state.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 COLLECTION="subaru"
-IMAGE="opencadc/${COLLECTION}2caom2"
+IMAGE="opencadc-metadata-curation/${COLLECTION}2caom2"
 
 echo "Get a proxy certificate"
 cp $HOME/.ssl/cadcproxy.pem ./ || exit $?

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/subaru2caom2
+github_project = opencadc-metadata-curation/subaru2caom2
 install_requires = caom2utils caom2repo cadcdata vos
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.2.0


### PR DESCRIPTION
This PR updates all references from `opencadc` to `opencadc-metadata-curation` following the repository transfer.

## Changes
- Updated Dockerfile dependencies and base images\n- Updated shell scripts\n
## Files Modified
```
Dockerfile
scripts/subaru_run.sh
scripts/subaru_run_remote.sh
scripts/subaru_run_state.sh
```

## Related
- Repository migration to opencadc-metadata-curation organization
- Ensures all references point to the correct organization

## Testing
- Verify builds pass
- Verify all references are updated correctly
