### PR TITLE
Update Dockerfile ARG variables for organization migration

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -25,7 +25,7 @@ ARG CAOM2_REPO=opencadc
 ARG OPENCADC_BRANCH=master
 ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
-ARG PIPE_REPO=opencadc
+ARG PIPE_REPO=opencadc-metadata-curation
 ARG VOS_BRANCH=master
 ARG VOS_REPO=opencadc
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,7 @@ WORKDIR /usr/src/app
 ARG CAOM2_BRANCH=master
 ARG CAOM2_REPO=opencadc
 ARG OPENCADC_BRANCH=master
-ARG OPENCADC_REPO=opencadc
+ARG OPENCADC_REPO=opencadc-metadata-curation
 ARG PIPE_BRANCH=master
 ARG PIPE_REPO=opencadc
 ARG VOS_BRANCH=master

--- a/setup.cfg
+++ b/setup.cfg
@@ -36,7 +36,7 @@ author_email = cadc@nrc-cnrc.gc.ca
 license = AGPLv3
 url = TBD
 edit_on_github = False
-github_project = opencadc/subaru2caom2
+github_project = opencadc-metadata-curation/subaru2caom2
 install_requires = caom2utils caom2repo cadcdata vos
 # version should be PEP386 compatible (http://www.python.org/dev/peps/pep-0386)
 version = 0.2.0


### PR DESCRIPTION
## Summary
Update Dockerfile ARG variables to reflect the repository transfer from opencadc to opencadc-metadata-curation organization.

## Changes
- Update PIPE_REPO from opencadc to opencadc-metadata-curation

This ensures pip install commands correctly reference the new repository location:
```
pip install git+https://github.com/opencadc-metadata-curation/caom2pipe
pip install git+https://github.com/opencadc-metadata-curation/subaru2caom2
```

Note: Docker base image references (FROM opencadc/...) remain unchanged as those are still hosted under the opencadc organization.